### PR TITLE
Empty line prevention.

### DIFF
--- a/lib/haproxy/socket_reader.rb
+++ b/lib/haproxy/socket_reader.rb
@@ -86,7 +86,7 @@ module HAProxy
       socket = UNIXSocket.new(@path)
       socket.write(cmd + ';')
       socket.each do |line|
-	next if line.chomp.empty?
+        next if line.chomp.empty?
         yield(line.strip)
       end
     end


### PR DESCRIPTION
In case when HAProxy socket returned empty line, exception was raised:

NoMethodError: undefined method `downcase' for nil:NilClass
        from ./lib/haproxy/socket_reader.rb:19:in`info'
        from ./lib/haproxy/socket_reader.rb:93:in `send_cmd'
        from ./lib/haproxy/socket_reader.rb:91:in`each'
        from ./lib/haproxy/socket_reader.rb:91:in `send_cmd'
        from ./lib/haproxy/socket_reader.rb:15:in`info'
        from ./lib/haproxy/stats_reader.rb:40:in `returning'
        from ./lib/haproxy/socket_reader.rb:14:in`info'
        from (irb):4
        from /usr/lib/ruby/1.8/prettyprint.rb:799

This will prevent such situations.
