### PR TITLE
fix the annoying message “warning: already initialized constant...

### DIFF
--- a/lib/haproxy/csv_parser.rb
+++ b/lib/haproxy/csv_parser.rb
@@ -2,8 +2,8 @@ module HAProxy
   class CSVParser
 
     # Uses CSV header from HAProxy 1.5, which is backwards compatible
-    COLUMNS = "pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt".split(",").map(&:to_sym)
-    LIMIT = COLUMNS.length
+    COLUMNS = "pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt".split(",").map(&:to_sym)  unless const_defined?(:COLUMNS)
+    LIMIT = COLUMNS.length  unless const_defined?(:LIMIT) 
 
     def self.parse(line)
       line.strip!


### PR DESCRIPTION
...”

fix the annoying message:
  “csv_parser.rb:5: warning: already initialized constant COLUMNS” 
  “csv_parser.rb:6: warning: already initialized constant LIMIT”
