### PR TITLE
Update socket_reader.rb

### DIFF
--- a/lib/haproxy/socket_reader.rb
+++ b/lib/haproxy/socket_reader.rb
@@ -93,7 +93,7 @@ module HAProxy
 
     def send_cmd(cmd, &block)
       UNIXSocket.open(@path) do |socket|
-        socket.write(cmd + ';')
+        socket.write(cmd + "\n")
         socket.each do |line|
           next if line.chomp.empty?
           yield(line.strip)


### PR DESCRIPTION
Newer versions of Haproxy now expects a new line when sending a command to the socket... you can either use "\n" instead of ';' , or you could change it to "socket.puts"... the previous version of this worked on Haproxy 1.6, but did not work on 2.2